### PR TITLE
PHPの組み込みの例外クラスを一覧する

### DIFF
--- a/php-declared-exceptions.php
+++ b/php-declared-exceptions.php
@@ -1,0 +1,7 @@
+<?php
+
+$declaredExceptions = array_filter(get_declared_classes(), function($className) {
+  return strrpos($className, 'Exception') !== false;
+});
+
+var_dump($declaredExceptions);

--- a/php-declared-exceptions.php
+++ b/php-declared-exceptions.php
@@ -4,4 +4,6 @@ $declaredExceptions = array_filter(get_declared_classes(), function($className) 
   return strrpos($className, 'Exception') !== false;
 });
 
+sort($declaredExceptions);
+
 var_dump($declaredExceptions);


### PR DESCRIPTION
refs #1 

次の通り対応した。
- PHPの組み込みクラスを`get_declared_classes()`で取得
- クラス名の末尾が **Exception** であるものを抽出
- クラス名の昇順でソート
- `var_dump()`で標準出力
